### PR TITLE
do not prompt user for config data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ dependencies:
 	. venv/bin/activate; pip install --upgrade -r requirements.txt
 
 configure:
-	echo "Configuring app..."
-	. venv/bin/activate; python configure.py $(CONFIG_FILE)
 	echo "Bootstrapping app..."
 	. venv/bin/activate; python bootstrap.py $(CONFIG_FILE)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -20,6 +20,14 @@ if __name__ == "__main__":
     except IOError:
         print "Configuration file not found - run `make install`"
         exit(-1)
+
+    for required_key in ['account_sid', 'auth_token', 'phone_number_sid']:
+        if required_key not in config:
+            print "*** ERROR ***"
+            print "config.json missing an entry: " + required_key
+            print "edit config.json and add your twilio secret data and try again"
+            exit(-2)
+
     print "Account SID: " + config['account_sid']
     print "Auth Token: " + config['auth_token']
     print "Phone Number SID: " + config['phone_number_sid']


### PR DESCRIPTION
## Description

the `make install` flow should not prompt a person to enter their account sid, auth token, or phone number sid.

From now on, we expect a student to edit their config.json file manually **before** running `make install`

Running `make install` or `make configure` when config.json file does not have twilio data will have the script abort.