### PR TITLE
depend on requests-security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ six==1.10.0
 Werkzeug==0.11.3
 wheel==0.24.0
 twilio
+requests[security]


### PR DESCRIPTION
students are often unable to make a https request due to SSL errors. Adding this module to requests is one solution.
